### PR TITLE
fixed doule // error

### DIFF
--- a/src/Channels/WaabotWhatsappChannel.php
+++ b/src/Channels/WaabotWhatsappChannel.php
@@ -42,7 +42,7 @@ class WaabotWhatsappChannel
 
         $client = $this->makeClient();
         $response = $client->post(sprintf(
-                '%s/whatsapp/message?session_id=%s&access_token=%s',
+                '%swhatsapp/message?session_id=%s&access_token=%s',
                 Config::get('services.waabot.url'),
                 Config::get('services.waabot.session_id'),
                 Config::get('services.waabot.access_token'),


### PR DESCRIPTION
Hi @Mane-Olawale, this PR aims to fix the 404 error faced when trying to use the package. I believe it's caused by the double slashes in the URL and this commit removes it. 
![simulator_screenshot_CFD1F91C-1A19-4579-A88D-36C6DFB83FBC](https://github.com/Mane-Olawale/waabot-laravel-notification-channel/assets/44205918/a6c93fd4-b045-4d42-96b0-5615fb8454a0)
